### PR TITLE
Add Predictions nav link

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,6 +35,7 @@ export default function RootLayout({
             <Link href="/about" className="hover:text-gray-300">About</Link>
             <Link href="/solutions" className="hover:text-gray-300">Solutions</Link>
             <Link href="/careers" className="hover:text-gray-300">Careers</Link>
+            <Link href="/presictions" className="hover:text-gray-300">Predictions</Link>
           </nav>
         </header>
         {children}

--- a/src/app/presictions/page.tsx
+++ b/src/app/presictions/page.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Predictions",
+};
+
+export default function PredictionsPage() {
+  return (
+    <main className="min-h-[calc(100vh-56px)] bg-black flex items-center justify-center">
+      <h1 className="text-white text-4xl font-semibold">Predictions</h1>
+    </main>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add Predictions tab to the navigation header
- implement /presictions route with placeholder page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689682f7e6b88321a57863386d19cedb