### PR TITLE
feat: add comment dialog for tweets and replies

### DIFF
--- a/src/components/CommentDialog.tsx
+++ b/src/components/CommentDialog.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type CommentDialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onPost?: (text: string) => void;
+};
+
+export default function CommentDialog({ isOpen, onClose, onPost }: CommentDialogProps) {
+  const [content, setContent] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setContent("");
+      setTimeout(() => textareaRef.current?.focus(), 0);
+    }
+  }, [isOpen]);
+
+  const handlePost = () => {
+    onPost?.(content);
+    onClose();
+    setContent("");
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="relative w-11/12 max-w-md rounded-xl border-[6px] border-white/10 bg-black/90 p-4 pb-14 shadow-lg">
+        <textarea
+          ref={textareaRef}
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          rows={3}
+          placeholder="Write a comment..."
+          className="block w-full resize-none bg-transparent text-white placeholder-gray-400 outline-none focus:ring-0"
+        />
+        <div className="absolute bottom-3 left-4 text-xs text-gray-400">
+          {content.length}
+        </div>
+        <button
+          type="button"
+          onClick={handlePost}
+          className="absolute bottom-2 right-3 rounded-md bg-white px-4 py-1 text-sm font-medium text-black transition hover:bg-gray-200"
+        >
+          Post
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/TweetComment.tsx
+++ b/src/components/TweetComment.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import Image from "next/image";
+import { useState } from "react";
+import CommentDialog from "@/components/CommentDialog";
 
 type TweetCommentProps = {
   onOpenThread?: () => void;
@@ -22,10 +24,12 @@ export default function TweetComment({
   replies,
 }: TweetCommentProps) {
   const handleLike = () => console.log("liked tweet");
-  const handleComment = () => console.log("commented on tweet");
+  const [isCommentOpen, setIsCommentOpen] = useState(false);
+  const handleComment = () => setIsCommentOpen(true);
 
   return (
-    <div className={`${fullWidth ? "w-full" : "w-full sm:w-2/3 lg:w-[35%]"} mx-auto mt-4`}>
+    <>
+      <div className={`${fullWidth ? "w-full" : "w-full sm:w-2/3 lg:w-[35%]"} mx-auto mt-4`}>
       <div
         className="rounded-xl border-[6px] border-white/10 bg-black/80 p-4 text-white shadow-md cursor-pointer"
         onClick={onOpenThread}
@@ -66,14 +70,23 @@ export default function TweetComment({
               <span>{likes ?? "15k"}</span>
             </button>
             <div className="flex-1" />
-            <button type="button" onClick={handleComment} className="flex items-center gap-2 rounded-md px-3 py-1 hover:bg-white/10">
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleComment();
+              }}
+              className="flex items-center gap-2 rounded-md px-3 py-1 hover:bg-white/10"
+            >
               <span>{"O>"}</span>
               <span>{replies ?? "32"}</span>
             </button>
           </div>
         </div>
+        </div>
       </div>
-    </div>
+      <CommentDialog isOpen={isCommentOpen} onClose={() => setIsCommentOpen(false)} />
+    </>
   );
 }
 

--- a/src/components/TweetTextCard.tsx
+++ b/src/components/TweetTextCard.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import Image from "next/image";
+import { useState } from "react";
+import CommentDialog from "@/components/CommentDialog";
 
 type TweetTextCardProps = {
   onOpenThread?: () => void;
@@ -38,15 +40,17 @@ export default function TweetTextCard({
     (typeof profileName === "string" || typeof profileName === "undefined") &&
     (typeof profileUrl === "string" || typeof profileUrl === "undefined");
 
+  const [isCommentOpen, setIsCommentOpen] = useState(false);
   if (!isValid) {
     return null;
   }
   const handleLike = () => console.log("liked tweet");
   const handleRestack = () => console.log("restacked tweet");
   const handleSave = () => console.log("saved tweet");
-  const handleComment = () => console.log("commented on tweet");
+  const handleComment = () => setIsCommentOpen(true);
   return (
-    <div className={`${fullWidth ? "w-full" : "w-full sm:w-2/3 lg:w-[35%]"} mx-auto mt-4`}>
+    <>
+      <div className={`${fullWidth ? "w-full" : "w-full sm:w-2/3 lg:w-[35%]"} mx-auto mt-4`}>
       <div
         className="rounded-xl border-[6px] border-white/10 bg-black/80 p-4 text-white shadow-md cursor-pointer"
         onClick={onOpenThread}
@@ -93,14 +97,23 @@ export default function TweetTextCard({
               <span>{"|v|"}</span>
               <span>{saves ?? "1k"}</span>
             </button>
-            <button type="button" onClick={handleComment} className="flex items-center gap-2 rounded-md px-3 py-1 hover:bg-white/10">
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                handleComment();
+              }}
+              className="flex items-center gap-2 rounded-md px-3 py-1 hover:bg-white/10"
+            >
               <span>{"O>"}</span>
               <span>{replies ?? "32"}</span>
             </button>
           </div>
         </div>
+        </div>
       </div>
-    </div>
+      <CommentDialog isOpen={isCommentOpen} onClose={() => setIsCommentOpen(false)} />
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add reusable `CommentDialog` component with textarea, character counter, and post button
- open the dialog when clicking comment buttons on tweets or comments

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: Unexpected any, react-hooks/exhaustive-deps)


------
https://chatgpt.com/codex/tasks/task_e_68981ccc957c8321b923086625b9ed00